### PR TITLE
Add Whisper transcription API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,27 @@
 # archivBot-voiceToText
-Voice to text
+
+Pequeña API en Flask que utiliza Whisper para convertir audio a texto.
+
+## Instalación
+
+```bash
+pip install -r requirements.txt
+```
+
+## Uso
+
+Iniciar el servidor:
+
+```bash
+python app.py
+```
+
+### Solicitud de transcripción
+
+Enviar un archivo `.mp3` (máximo 1MB):
+
+```bash
+curl -X POST -F "file=@audio.mp3" http://localhost:5000/transcribe
+```
+
+La respuesta será un JSON con el texto transcrito.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,39 @@
+from flask import Flask, request, jsonify
+import whisper
+import os
+import tempfile
+
+app = Flask(__name__)
+
+# Cargamos el modelo 'base' de Whisper al iniciar la aplicación
+# Esto evita recargarlo en cada solicitud
+model = whisper.load_model("base")
+
+# Tamaño máximo permitido para el archivo mp3 (1MB)
+MAX_FILE_SIZE = 1 * 1024 * 1024
+
+@app.route('/transcribe', methods=['POST'])
+def transcribe_audio():
+    """Recibe un archivo mp3 y devuelve su transcripción en texto."""
+    if 'file' not in request.files:
+        return jsonify({'error': 'Archivo no proporcionado'}), 400
+
+    file = request.files['file']
+
+    # Verificamos el tamaño del archivo
+    file.seek(0, os.SEEK_END)
+    size = file.tell()
+    file.seek(0)
+    if size > MAX_FILE_SIZE:
+        return jsonify({'error': 'El archivo supera el límite de 1MB'}), 400
+
+    # Guardamos temporalmente el archivo para procesarlo con Whisper
+    with tempfile.NamedTemporaryFile(suffix='.mp3') as tmp:
+        file.save(tmp.name)
+        result = model.transcribe(tmp.name)
+
+    return jsonify({'text': result['text']})
+
+if __name__ == '__main__':
+    # Ejecutamos la aplicación de desarrollo
+    app.run(host='0.0.0.0', port=5000, debug=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+flask
+openai-whisper


### PR DESCRIPTION
## Summary
- implement Flask API to transcribe mp3 files using Whisper
- document installation and usage steps
- declare dependencies

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6872e152beb08325a3438b38bc67b4f5