### PR TITLE
Add Spanish NER FastAPI using spaCy es_core_news_sm

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,35 @@
 # archivBot-voiceToText
+
 Voice to text
+
+## API de Reconocimiento de Entidades (NER)
+
+Esta API en Python utiliza FastAPI y spaCy con el modelo `es_core_news_sm`
+para extraer entidades nombradas de un texto en español.
+
+### Requisitos
+
+1. Python 3.9 o superior (macOS, Windows o Linux).
+2. Instalar las dependencias:
+
+```bash
+pip install -r requerimiento.txt
+```
+
+### Ejecutar la API
+
+Iniciar el servidor con:
+
+```bash
+uvicorn main:app --host 0.0.0.0 --port 8000
+```
+
+### Probar con cURL
+
+```bash
+curl -X POST "http://localhost:8000/ner" \
+     -H "Content-Type: application/json" \
+     -d '{"text": "Barack Obama nació en Estados Unidos"}'
+```
+
+El comando devolverá un JSON con las entidades reconocidas.

--- a/main.py
+++ b/main.py
@@ -1,0 +1,56 @@
+# -*- coding: utf-8 -*-
+"""Aplicación de reconocimiento de entidades nombradas (NER) en español.
+
+Esta API utiliza FastAPI y la librería de procesamiento de lenguaje natural
+spaCy con el modelo ``es_core_news_sm`` para identificar entidades en un texto.
+Funciona en macOS, Windows y Linux.
+"""
+
+from fastapi import FastAPI
+from pydantic import BaseModel
+import spacy
+
+# Cargamos el modelo de spaCy para español una única vez al iniciar la app.
+# Esto evita recargarlo en cada petición y mejora el rendimiento.
+nlp = spacy.load("es_core_news_sm")
+
+# Creamos la instancia de la aplicación FastAPI.
+app = FastAPI(title="API NER en español")
+
+
+class Texto(BaseModel):
+    """Estructura de los datos de entrada.
+
+    Espera un JSON con una clave ``text`` que contenga el texto a analizar.
+    """
+
+    text: str
+
+
+@app.post("/ner")
+def obtener_entidades(data: Texto):
+    """Extrae las entidades nombradas del texto recibido.
+
+    Args:
+        data (Texto): Objeto con el texto a analizar.
+
+    Returns:
+        dict: Diccionario con una lista de entidades encontradas.
+    """
+
+    # Procesamos el texto con el modelo de spaCy para obtener las entidades.
+    documento = nlp(data.text)
+
+    # Construimos una lista con la información relevante de cada entidad.
+    entidades = [
+        {
+            "text": entidad.text,       # Texto exacto de la entidad
+            "label": entidad.label_,    # Tipo de entidad (persona, lugar, etc.)
+            "start": entidad.start_char, # Posición inicial en el texto
+            "end": entidad.end_char      # Posición final en el texto
+        }
+        for entidad in documento.ents
+    ]
+
+    # Devolvemos las entidades en formato JSON.
+    return {"entities": entidades}

--- a/requerimiento.txt
+++ b/requerimiento.txt
@@ -1,0 +1,4 @@
+fastapi
+uvicorn
+spacy
+es-core-news-sm


### PR DESCRIPTION
## Summary
- implement FastAPI endpoint `/ner` that loads spaCy's `es_core_news_sm` model
- add requirements file listing FastAPI, spaCy and model dependencies
- extend README with installation, run and curl usage instructions

## Testing
- `pip install -r requerimiento.txt` *(fails: Could not find a version that satisfies the requirement fastapi)*
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_68a0f3f32d488325ad67284d1fdd44bd